### PR TITLE
Revert "Shorten data types"

### DIFF
--- a/SOURCES/include/datasketches/theta/theta_common.hpp
+++ b/SOURCES/include/datasketches/theta/theta_common.hpp
@@ -49,14 +49,17 @@ class ThetaSketchAggregateFunctionFactory : public AggregateFunctionFactory {
                                       const SizedColumnTypes &inputTypes,
                                       SizedColumnTypes &intermediateTypeMetaData) {
         uint8_t logK = readLogK(srvInterface);
-        intermediateTypeMetaData.addVarbinary(quickSelectSketchMinSize(logK));
+        intermediateTypeMetaData.addLongVarbinary(quickSelectSketchMaxSize(logK)*8);
+        intermediateTypeMetaData.addLongVarbinary(320000);
+        intermediateTypeMetaData.addInt();
+        intermediateTypeMetaData.addInt();
     }
 
     virtual void getReturnType(ServerInterface &srvfloaterface,
                                const SizedColumnTypes &inputTypes,
                                SizedColumnTypes &outputTypes) {
         uint8_t logK = readLogK(srvfloaterface);
-        outputTypes.addVarbinary(quickSelectSketchMinSize(logK));
+        outputTypes.addLongVarbinary(quickSelectSketchMaxSize(logK)*8);
     }
 
     virtual void getParameterType(ServerInterface &srvInterface,

--- a/SOURCES/src/datasketches/frequency/FrequencyAggregateCreate.cpp
+++ b/SOURCES/src/datasketches/frequency/FrequencyAggregateCreate.cpp
@@ -22,8 +22,8 @@ uint8_t readTopK(ServerInterface &serverInterface) {
         }
     } else {
         LogDebugUDxWarn(serverInterface, "Parameter %s was not provided. Defaulting to %d",
-                        "topK", 1000);
-        topK = 1000;
+                        "topK", 10);
+        topK = 10;
     }
     return topK;
 }

--- a/SOURCES/src/datasketches/theta/AggregateCreate.cpp
+++ b/SOURCES/src/datasketches/theta/AggregateCreate.cpp
@@ -81,7 +81,7 @@ class ThetaSketchAggregateCreate : public ThetaSketchAggregateFunction {
 class ThetaSketchAggregateCreateVarcharFactory : public ThetaSketchAggregateFunctionFactory {
     virtual void getPrototype(ServerInterface &srvfloaterface, ColumnTypes &argTypes, ColumnTypes &returnType) {
         argTypes.addVarchar();
-        returnType.addVarbinary();
+        returnType.addLongVarbinary();
     }
 
     virtual AggregateFunction *createAggregateFunction(ServerInterface &srvfloaterface) {
@@ -93,7 +93,7 @@ class ThetaSketchAggregateCreateVarcharFactory : public ThetaSketchAggregateFunc
 class ThetaSketchAggregateCreateVarbinaryFactory : public ThetaSketchAggregateFunctionFactory {
     virtual void getPrototype(ServerInterface &srvfloaterface, ColumnTypes &argTypes, ColumnTypes &returnType) {
         argTypes.addVarbinary();
-        returnType.addVarbinary();
+        returnType.addLongVarbinary();
     }
 
     virtual AggregateFunction *createAggregateFunction(ServerInterface &srvfloaterface) {


### PR DESCRIPTION
Hi Bryan,
What do you think about adding back LongVarbinary instead of Varbinary?
Sketches in size of more than 64KB (a common scenario) requires that.
I actually reverted the commit on my environment and the queries timed out (as opposed to with my fork [yurmix/vertica-datasketch#LongVarbinary](https://github.com/yurmix/vertica-datasketch/tree/LongVarbinary), so I might be missing something here. What do you think?